### PR TITLE
changed server location detection from request

### DIFF
--- a/muntjac/terminal/gwt/server/abstract_application_servlet.py
+++ b/muntjac/terminal/gwt/server/abstract_application_servlet.py
@@ -1693,13 +1693,17 @@ class AbstractApplicationServlet(PasteWsgiServlet, Constants):
                     data store represented by the given URL.
         """
         reqURL = 'https://' if self.isSecure(request) else 'http://'
-        reqURL += self.getServerName(request)
-        if (self.isSecure(request) and self.getServerPort(request) == 443
-                or (not self.isSecure(request)
-                        and self.getServerPort(request) == 80)):
-            reqURL += ''
+        reqHost = request.environ().get('HTTP_HOST')
+        if reqHost:
+            reqURL += reqHost
         else:
-            reqURL += ':%d' % self.getServerPort(request)
+            reqURL += self.getServerName(request)
+            if (self.isSecure(request) and self.getServerPort(request) == 443
+                    or (not self.isSecure(request)
+                            and self.getServerPort(request) == 80)):
+                pass
+            else:
+                reqURL += ':%d' % self.getServerPort(request)
         reqURL += self.getRequestUri(request)
 
         # FIXME: implement include requests


### PR DESCRIPTION
Method call self.getServerName(request) of abstract_application_servlet returns always the same name of the 
network node. But, I suppose, we need get the node name from the request.
